### PR TITLE
Dev bheejun : Redis를 활용한 친구요청 거절 상태 관리 기능 추가

### DIFF
--- a/src/main/java/com/mogakko/be_final/domain/friendship/entity/RejectedFriendship.java
+++ b/src/main/java/com/mogakko/be_final/domain/friendship/entity/RejectedFriendship.java
@@ -1,0 +1,23 @@
+package com.mogakko.be_final.domain.friendship.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Getter
+@NoArgsConstructor
+public class RejectedFriendship {
+
+    private String member1Nickname;
+
+    private String member2Nickname;
+
+    private long rejectionTime;
+
+    public RejectedFriendship(String member1Nickname, String member2Nickname) {
+        this.member1Nickname = member1Nickname;
+        this.member2Nickname = member2Nickname;
+        this.rejectionTime = Instant.now().toEpochMilli();
+    }
+}

--- a/src/main/java/com/mogakko/be_final/redis/util/RedisUtil.java
+++ b/src/main/java/com/mogakko/be_final/redis/util/RedisUtil.java
@@ -1,5 +1,6 @@
 package com.mogakko.be_final.redis.util;
 
+import com.mogakko.be_final.domain.friendship.entity.RejectedFriendship;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
@@ -13,6 +14,7 @@ public class RedisUtil {
 
     private final RedisTemplate<String, String> redisTemplate;
     private final RedisTemplate<String, String> redisBlackListTemplate;
+    private final RedisTemplate<String, Object> redisFriendshipTemplate;
 
     public void set(String key, String val, long time) {
         redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(val.getClass()));
@@ -50,5 +52,17 @@ public class RedisUtil {
 
     public boolean hasKeyBlackList(String key) {
         return Boolean.TRUE.equals(redisBlackListTemplate.hasKey(key));
+    }
+
+    public void setRejectedFriendshipWithExpireTime(String key, Object value, long timeout, TimeUnit unit) {
+       redisFriendshipTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(RejectedFriendship.class));
+       redisFriendshipTemplate.opsForValue().set(key, value, timeout, unit);    }
+
+    public boolean hasKeyFriendship(String key) {
+        return Boolean.TRUE.equals(redisFriendshipTemplate.hasKey(key));
+    }
+
+    public Long getExpire(String key, TimeUnit unit) {
+        return redisTemplate.getExpire(key, unit);
     }
 }

--- a/src/main/java/com/mogakko/be_final/security/oauth2/service/GitHubLoginService.java
+++ b/src/main/java/com/mogakko/be_final/security/oauth2/service/GitHubLoginService.java
@@ -97,7 +97,6 @@ public class GitHubLoginService {
             );
             member.setGithubId((String) map.get("login"));
             membersRepository.save(member);
-            System.out.println(member);
         }else {
             throw new CustomException(FAILED_TO_GET_USERINFO);
         }


### PR DESCRIPTION
Redis 의 TTL 기능을 활용해 일정 시간이 지나면 다시 친구 요청을 할 수 있도록 기능을 구현 해 보았습니다. 
그리고 거절 상태일 시, 만료 시간이 얼마나 남았는지 반환하도록 했습니다. 
우선은 만료 시간을 하루로 설정해 두었는데, 다 같이 상의해서 어느 정도 시간이 적당할지 정하면 좋을 것 같습니다.